### PR TITLE
Ensure build artifacts stay in sync with the tool surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "build": "tsc",
     "lint": "eslint .",
     "format": "prettier --write .",
+    "prepack": "pnpm run build",
+    "prepublishOnly": "pnpm test",
+    "pretest": "pnpm run build",
     "test": "vitest run --coverage",
+    "pretest:watch": "pnpm run build",
     "test:watch": "vitest",
     "openapi-ts": "openapi-ts",
     "inspect": "pnpm dlx @modelcontextprotocol/inspector dist/index.js"

--- a/release.sh
+++ b/release.sh
@@ -17,6 +17,13 @@ fi
 # Update package.json version
 pnpm dlx json -I -f package.json -e "this.version='$VERSION'"
 
+# Ensure the build artifacts are up to date before committing
+echo "Running build..."
+pnpm build || exit 1
+
+echo "Running tests..."
+pnpm test || exit 1
+
 # Commit the change
 git add package.json
 git commit -m "chore: bump version to $VERSION"

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
 import { close, connect } from "mcp-testing-kit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as helpers from "./client/helpers";
@@ -8,6 +10,63 @@ vi.mock("./client/sdk.gen");
 vi.mock("./client/helpers");
 vi.mock("axios");
 
+const expectedToolNames = [
+  "coda_list_documents",
+  "coda_get_document",
+  "coda_create_document",
+  "coda_update_document",
+  "coda_list_pages",
+  "coda_create_page",
+  "coda_delete_page",
+  "coda_get_page_content",
+  "coda_peek_page",
+  "coda_replace_page_content",
+  "coda_append_page_content",
+  "coda_duplicate_page",
+  "coda_rename_page",
+  "coda_list_tables",
+  "coda_get_table",
+  "coda_get_table_summary",
+  "coda_list_columns",
+  "coda_get_column",
+  "coda_list_rows",
+  "coda_get_row",
+  "coda_create_rows",
+  "coda_update_row",
+  "coda_delete_row",
+  "coda_delete_rows",
+  "coda_list_formulas",
+  "coda_get_formula",
+  "coda_list_controls",
+  "coda_get_control",
+  "coda_push_button",
+  "coda_whoami",
+  "coda_search_tables",
+  "coda_search_pages",
+  "coda_bulk_update_rows",
+  "coda_get_document_stats",
+];
+
+const prettyJson = (value: unknown) => JSON.stringify(value, null, 2);
+
+if (typeof Promise.withResolvers !== "function") {
+  Object.defineProperty(Promise, "withResolvers", {
+    configurable: true,
+    writable: true,
+    value: <T>() => {
+      let resolve!: (value: T | PromiseLike<T>) => void;
+      let reject!: (reason?: unknown) => void;
+
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+
+      return { promise, resolve, reject };
+    },
+  });
+}
+
 describe("MCP Server", () => {
   afterEach(async () => {
     await close(mcpServer.server);
@@ -17,17 +76,24 @@ describe("MCP Server", () => {
   it("should have all tools", async () => {
     const client = await connect(mcpServer.server);
     const result = await client.listTools();
-    expect(result.tools).toEqual([
-      expect.objectContaining({ name: "coda_list_documents" }),
-      expect.objectContaining({ name: "coda_list_pages" }),
-      expect.objectContaining({ name: "coda_create_page" }),
-      expect.objectContaining({ name: "coda_get_page_content" }),
-      expect.objectContaining({ name: "coda_peek_page" }),
-      expect.objectContaining({ name: "coda_replace_page_content" }),
-      expect.objectContaining({ name: "coda_append_page_content" }),
-      expect.objectContaining({ name: "coda_duplicate_page" }),
-      expect.objectContaining({ name: "coda_rename_page" }),
-    ]);
+    expect(result.tools).toBeDefined();
+    const toolNames = (result.tools ?? []).map(({ name }) => name);
+
+    expect(toolNames).toEqual(expect.arrayContaining(expectedToolNames));
+    expect(toolNames).toHaveLength(expectedToolNames.length);
+  });
+
+  it("should include all tools in the built artifact", async () => {
+    const distPath = join(__dirname, "..", "dist", "server.js");
+    await expect(fs.access(distPath)).resolves.toBeUndefined();
+
+    const distContents = await fs.readFile(distPath, "utf8");
+    const toolRegistrations = distContents.match(/server\.tool\(/g) ?? [];
+
+    expect(toolRegistrations).toHaveLength(expectedToolNames.length);
+    expectedToolNames.forEach((toolName) => {
+      expect(distContents).toContain(toolName);
+    });
   });
 });
 
@@ -47,7 +113,7 @@ describe("coda_list_documents", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           items: [
             { id: "123", name: "Test Document" },
             { id: "456", name: "Another Document" },
@@ -69,7 +135,7 @@ describe("coda_list_documents", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           items: [{ id: "123", name: "Test Document" }],
         }),
       },
@@ -81,7 +147,7 @@ describe("coda_list_documents", () => {
 
     const client = await connect(mcpServer.server);
     const result = await client.callTool("coda_list_documents", { query: "test" });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to list documents: Error: foo" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Failed to list documents : foo" }]);
   });
 });
 
@@ -101,7 +167,7 @@ describe("coda_list_pages", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           items: [
             { id: "page-123", name: "Test Page 1" },
             { id: "page-456", name: "Test Page 2" },
@@ -132,7 +198,7 @@ describe("coda_list_pages", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           items: [
             { id: "page-123", name: "Test Page 1" },
             { id: "page-456", name: "Test Page 2" },
@@ -166,7 +232,7 @@ describe("coda_list_pages", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           items: [
             { id: "page-789", name: "Test Page 3" },
             { id: "page-101", name: "Test Page 4" },
@@ -197,7 +263,7 @@ describe("coda_list_pages", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           items: [{ id: "page-789", name: "Test Page 3" }],
         }),
       },
@@ -215,7 +281,7 @@ describe("coda_list_pages", () => {
 
     const client = await connect(mcpServer.server);
     const result = await client.callTool("coda_list_pages", { docId: "doc-123" });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to list pages: Error: Access denied" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Failed to list pages : Access denied" }]);
   });
 });
 
@@ -237,7 +303,7 @@ describe("coda_create_page", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           id: "page-new",
           requestId: "req-123",
         }),
@@ -247,6 +313,9 @@ describe("coda_create_page", () => {
       path: { docId: "doc-123" },
       body: {
         name: "New Page",
+        subtitle: undefined,
+        iconName: undefined,
+        parentPageId: undefined,
         pageContent: {
           type: "canvas",
           canvasContent: { format: "markdown", content: "# Hello World" },
@@ -273,6 +342,9 @@ describe("coda_create_page", () => {
       path: { docId: "doc-123" },
       body: {
         name: "Empty Page",
+        subtitle: undefined,
+        iconName: undefined,
+        parentPageId: undefined,
         pageContent: {
           type: "canvas",
           canvasContent: { format: "markdown", content: " " },
@@ -300,13 +372,15 @@ describe("coda_create_page", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({ id: "page-sub", requestId: "req-125" }),
+        text: prettyJson({ id: "page-sub", requestId: "req-125" }),
       },
     ]);
     expect(sdk.createPage).toHaveBeenCalledWith({
       path: { docId: "doc-123" },
       body: {
         name: "Subpage",
+        subtitle: undefined,
+        iconName: undefined,
         parentPageId: "page-456",
         pageContent: {
           type: "canvas",
@@ -325,7 +399,9 @@ describe("coda_create_page", () => {
       docId: "doc-123",
       name: "New Page",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to create page: Error: Insufficient permissions" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to create page : Insufficient permissions" },
+    ]);
   });
 });
 
@@ -372,7 +448,7 @@ describe("coda_get_page_content", () => {
       pageIdOrName: "page-456",
     });
     expect(result.content).toEqual([
-      { type: "text", text: "Failed to get page content: Error: Unknown error has occurred" },
+      { type: "text", text: "Failed to get page content : Unknown error has occurred" },
     ]);
   });
 
@@ -384,7 +460,7 @@ describe("coda_get_page_content", () => {
       docId: "doc-123",
       pageIdOrName: "page-456",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to get page content: Error: Export failed" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Failed to get page content : Export failed" }]);
   });
 });
 
@@ -416,7 +492,9 @@ describe("coda_peek_page", () => {
       pageIdOrName: "page-456",
       numLines: 1,
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to peek page: Error: Unknown error has occurred" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to peek page : Unknown error has occurred" },
+    ]);
   });
 
   it("should show error if getPageContent throws", async () => {
@@ -428,7 +506,7 @@ describe("coda_peek_page", () => {
       pageIdOrName: "page-456",
       numLines: 3,
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to peek page: Error: Export failed" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Failed to peek page : Export failed" }]);
   });
 });
 
@@ -450,7 +528,7 @@ describe("coda_replace_page_content", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           id: "page-456",
           requestId: "req-125",
         }),
@@ -477,7 +555,9 @@ describe("coda_replace_page_content", () => {
       pageIdOrName: "page-456",
       content: "# New Content",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to replace page content: Error: Update failed" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to replace page content : Update failed" },
+    ]);
   });
 });
 
@@ -499,7 +579,7 @@ describe("coda_append_page_content", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           id: "page-456",
           requestId: "req-126",
         }),
@@ -526,7 +606,9 @@ describe("coda_append_page_content", () => {
       pageIdOrName: "page-456",
       content: "Additional content",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to append page content: Error: Append failed" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to append page content : Append failed" },
+    ]);
   });
 });
 
@@ -549,7 +631,7 @@ describe("coda_duplicate_page", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           id: "page-duplicate",
           requestId: "req-127",
         }),
@@ -578,7 +660,9 @@ describe("coda_duplicate_page", () => {
       pageIdOrName: "page-456",
       newName: "Duplicated Page",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to duplicate page: Error: Content fetch failed" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to duplicate page : Content fetch failed" },
+    ]);
   });
 
   it("should show error if createPage fails during duplication", async () => {
@@ -591,7 +675,9 @@ describe("coda_duplicate_page", () => {
       pageIdOrName: "page-456",
       newName: "Duplicated Page",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to duplicate page: Error: Create failed" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to duplicate page : Create failed" },
+    ]);
   });
 });
 
@@ -613,7 +699,7 @@ describe("coda_rename_page", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({
+        text: prettyJson({
           id: "page-456",
           requestId: "req-128",
         }),
@@ -637,6 +723,8 @@ describe("coda_rename_page", () => {
       pageIdOrName: "page-456",
       newName: "Renamed Page",
     });
-    expect(result.content).toEqual([{ type: "text", text: "Failed to rename page: Error: Rename failed" }]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Failed to rename page : Rename failed" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- run the TypeScript build automatically before packaging, publishing, or invoking the Vitest suite so the dist output stays current
- update the release script to rebuild and retest before tagging to avoid shipping stale tool registrations
- refresh the MCP server tests to cover all 34 tools, assert pretty-printed payloads, polyfill Promise.withResolvers, and verify the built artifact matches the source

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0ba8a5450832cad4249fadc6835d6