### PR TITLE
Enhance tool pagination coverage and search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The server exposes the following tools to the MCP client:
 ### User Operations
 - **`coda_whoami`**: Get information about the current authenticated user
 
-**Note**: This MCP server provides comprehensive CRUD operations for existing Coda elements but cannot create new tables or other canvas elements due to Coda API limitations. Total: **34 tools** available.
+**Note**: This MCP server provides comprehensive CRUD operations for existing Coda elements but cannot create new tables or other canvas elements due to Coda API limitations. Total: **35 tools** available.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- add pagination helpers and optional query filters so document, table, column, and row tools expose the full API surface
- fetch every page/table when searching and when computing document stats, and support the document creation timezone option
- expand test coverage for the new pagination behaviour and fix the README tool count

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0cbf8f3ac832cb2e8046bc5916343