### PR TITLE
Validate API key configuration before starting server

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,15 @@
-type Config = {
+export type Config = {
   apiKey: string;
 };
 
-export const config: Config = {
-  apiKey: process.env.API_KEY!,
+export const getConfig = (): Config => {
+  const apiKey = process.env.API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      "The API_KEY environment variable is required to start the Coda MCP server. Please set API_KEY to your Coda API token.",
+    );
+  }
+
+  return { apiKey };
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { main } from "./index";
+import { server } from "./server";
+
+const originalApiKey = process.env.API_KEY;
+
+afterEach(() => {
+  if (originalApiKey === undefined) {
+    delete process.env.API_KEY;
+  } else {
+    process.env.API_KEY = originalApiKey;
+  }
+
+  vi.restoreAllMocks();
+});
+
+describe("main", () => {
+  it("rejects when API_KEY environment variable is missing", async () => {
+    delete process.env.API_KEY;
+
+    const connectSpy = vi.spyOn(server, "connect");
+
+    await expect(main()).rejects.toThrowError(
+      /API_KEY environment variable is required/i,
+    );
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { client } from "./client/client.gen";
-import { config } from "./config";
+import { getConfig } from "./config";
 import { server } from "./server";
 
-async function main() {
+export async function main() {
+  const config = getConfig();
+
   // Initialize Axios Client
   client.setConfig({
     baseURL: "https://coda.io/apis/v1",
@@ -20,7 +22,9 @@ async function main() {
   console.error("Coda MCP server running on stdio");
 }
 
-main().catch((error) => {
-  console.error("Fatal error in main():", error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("Fatal error in main():", error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- throw a clear error when `API_KEY` is missing while loading configuration
- make the startup routine use the validated config before opening the MCP transport
- add a unit test to confirm startup rejects when `API_KEY` is absent

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d0c1d33fa0832c8a88f1b5e9652804